### PR TITLE
DSODA-219 hide tracks from previous shows that started more than 1 ho…

### DIFF
--- a/app/controllers/listen.js
+++ b/app/controllers/listen.js
@@ -24,12 +24,15 @@ export default Controller.extend({
   _tracksAreStale: function() {
     let showStartTimeTs = this.model.stream.currentShow.start_ts;
     let trackStartTimeTs = 0;
+    let currentShowTracks = [];
 
-    let currentShowTracks = this.model.stream.previous.filter( (track) => {
-      return track.startTimeTs >= showStartTimeTs;
-    });
+    if (this.model.stream.previous) {
+      currentShowTracks = this.model.stream.previous.filter( (track) => {
+        return track.startTimeTs >= showStartTimeTs;
+      });
+    }
 
-    if (this.model.stream.previous.length > 0 && currentShowTracks.length == this.model.stream.previous.length) {
+    if (this.model.stream.previous && this.model.stream.previous.length > 0 && currentShowTracks.length == this.model.stream.previous.length) {
       return false; // all previous tracks are from the current show
     } else if (currentShowTracks.length > 0) {
       trackStartTimeTs = currentShowTracks[currentShowTracks.length - 1].startTimeTs; // get the earliest-starting track from the current show

--- a/app/controllers/listen.js
+++ b/app/controllers/listen.js
@@ -8,6 +8,7 @@ export default Controller.extend({
   appController: controller('application'),
   currentStream  : service(),
   SHOW_STALE_CUTOFF: 15 * 60,
+  PREVIOUS_SHOW_TRACKS_STALE_CUTOFF: 60 * 60,
 
   isPlaylistHistoryPreviewStale: computed('clock.minute', function () {
     return this._currentShowStartedMoreThanFifteenMinutesAgo() && this._tracksAreStale();
@@ -48,7 +49,9 @@ export default Controller.extend({
       });
     }
 
-    return this.model.stream.previous;
+    return this.model.stream.previous.filter( (track) => {
+      return track.startTimeTs >= (showStartTimeTs - this.PREVIOUS_SHOW_TRACKS_STALE_CUTOFF);
+    });
   }),
 
   actions: {

--- a/app/controllers/listen.js
+++ b/app/controllers/listen.js
@@ -44,6 +44,10 @@ export default Controller.extend({
   },
 
   playlistHistoryItems: computed('model.stream.previous', function() {
+    if (!this.model.stream.previous) {
+      return [];
+    }
+
     let showStartTimeTs = this.model.stream.currentShow.start_ts;
 
     if (this._currentShowStartedMoreThanFifteenMinutesAgo() && this._tracksAreStale() && this.model.stream.previous) {

--- a/tests/unit/controllers/listen-test.js
+++ b/tests/unit/controllers/listen-test.js
@@ -200,4 +200,16 @@ module('Unit | Controller | listen', function(hooks) {
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), false);
     assert.equal(controller.get('playlistHistoryItems').length, 2);
   });
+
+  test('previous is undefined', function(assert) {
+    let controller = this.owner.lookup('controller:listen');
+    let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(60));
+    let model = {
+      stream: stream
+    }
+    controller.set('model', model);
+
+    assert.equal(controller.get('isPlaylistHistoryPreviewStale'), true);
+  });
 });

--- a/tests/unit/controllers/listen-test.js
+++ b/tests/unit/controllers/listen-test.js
@@ -5,6 +5,39 @@ import { run } from '@ember/runloop';
 import moment from "moment";
 import Ember from 'ember';
 
+function minutesBeforeNowMeasuredInSecondsSince1970Epoch(minutes) {
+  return (moment().valueOf() / 1000) - (minutes * 60);
+}
+
+function createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(startTime) {
+  return EmberObject.create({
+    start_ts: minutesBeforeNowMeasuredInSecondsSince1970Epoch(startTime),
+  });
+}
+
+function createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow(startTimes) {
+	var tracks = [];
+	for (let i=0; i<startTimes.length; i++) {
+		tracks.push(
+      EmberObject.create({
+        startTimeTs: minutesBeforeNowMeasuredInSecondsSince1970Epoch(startTimes[i]),
+      }),
+		);
+	}
+	return tracks;
+}
+
+function createCurrentPlaylistItemWithStartTimeTsValueMeasuredAsMinutesBeforeNow(startTime) {
+  return EmberObject.create({
+    catalogEntry: EmberObject.create({
+      composer: {
+        name: 'lorem'
+      }
+    }),
+    startTimeTs: minutesBeforeNowMeasuredInSecondsSince1970Epoch(startTime)
+  });
+}
+
 module('Unit | Controller | listen', function(hooks) {
   setupTest(hooks);
 
@@ -15,161 +48,79 @@ module('Unit | Controller | listen', function(hooks) {
 
   test('playlist history should not be stale if show started less than 15 minutes ago', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (14 * 60), // show started 14 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (30 * 60), // started 30 minutes ago
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (40 * 60), // 40 minutes ago
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (45* 60), // 45 minutes ago
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(14));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([30, 40, 45]));
     let model = {
       stream: stream
     }
     controller.set('model', model);
+
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), false);
     assert.equal(controller.get('playlistHistoryItems').length, 3); // all 3 tracks from earlier show should display
   });
 
   test('no current track - playlist history should be stale if there are no previous playlist items', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (1 * 60 * 60), // show started 1 hour ago
-    });
-    stream.set('currentShow', currentShow);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(60));
     stream.set('previous', []);
     let model = {
       stream: stream
     }
     controller.set('model', model);
+
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), true);
   });
 
   test('no tracks from earlier show should display if show started more than 15 minutes ago and there are no tracks from current show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (2 * 60 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([120, 180, 240]));
     let model = {
       stream: stream
     }
     controller.set('model', model);
+
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), true);
     assert.equal(controller.get('playlistHistoryItems').length, 0); // no tracks from earlier show should display
   });
 
   test('playlist history should  only display tracks for current show if first track for show started more than 15 minutes after start of show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000), // track started right now
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([0, 180, 240]));
     let model = {
       stream: stream
     }
     controller.set('model', model);
+
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), true);
     assert.equal(controller.get('playlistHistoryItems').length, 1);
   });
 
   test('playlist history should  only display previous tracks from earlier show if first track for show started less than 15 minutes after start of show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (10 * 60), // track started 10 minutes ago
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (30 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (40 * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([10, 30, 40]));
     let model = {
       stream: stream
     }
     controller.set('model', model);
+    
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), false);
     assert.equal(controller.get('playlistHistoryItems').length, 3);
   });
 
   test('tracks from earlier show should display if show started more than 15 minutes ago and current track started within first 15 minutes show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let currentPlaylistItem = EmberObject.create({
-      catalogEntry: EmberObject.create({
-        composer: {
-          name: 'lorem'
-        }
-      }),
-      startTimeTs: (moment().valueOf() / 1000) - (10 * 60)
-    });
-    stream.set('currentPlaylistItem', currentPlaylistItem);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (30 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (31 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (32 * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('currentPlaylistItem', createCurrentPlaylistItemWithStartTimeTsValueMeasuredAsMinutesBeforeNow(10));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([30, 31, 32]));
     let model = {
       stream: stream
     }
@@ -184,33 +135,10 @@ module('Unit | Controller | listen', function(hooks) {
 
   test('tracks from earlier show should NOT display if show started more than 15 minutes ago and current track started after the first 15 minutes of the show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let currentPlaylistItem = EmberObject.create({
-      catalogEntry: EmberObject.create({
-        composer: {
-          name: 'lorem'
-        }
-      }),
-      startTimeTs: (moment().valueOf() / 1000)
-    });
-    stream.set('currentPlaylistItem', currentPlaylistItem);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (2 * 60 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('currentPlaylistItem', createCurrentPlaylistItemWithStartTimeTsValueMeasuredAsMinutesBeforeNow(0));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([120, 180, 240]));
     let model = {
       stream: stream
     }
@@ -225,33 +153,10 @@ module('Unit | Controller | listen', function(hooks) {
 
 	test('playlist history should not be stale if all previous tracks are from the current show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (2 * 60 * 60), // show started 2 hours ago
-    });
-    stream.set('currentShow', currentShow);
-    let currentPlaylistItem = EmberObject.create({
-      catalogEntry: EmberObject.create({
-        composer: {
-          name: 'lorem'
-        }
-      }),
-      startTimeTs: (moment().valueOf() / 1000)
-    });
-    stream.set('currentPlaylistItem', currentPlaylistItem);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (1 * 60), // started 1 minute
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60), // 3 minutes ago
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (5 * 60), // 5 minutes ago
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(120));
+    stream.set('currentPlaylistItem', createCurrentPlaylistItemWithStartTimeTsValueMeasuredAsMinutesBeforeNow(0));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([1, 3, 5]));
     let model = {
       stream: stream
     }
@@ -266,24 +171,9 @@ module('Unit | Controller | listen', function(hooks) {
 
   test('no current track - playlist history should not be stale if all previous tracks are from the current show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (2 * 60 * 60), // show started 2 hours ago
-    });
-    stream.set('currentShow', currentShow);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (1 * 60), // started 1 minute
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60), // 3 minutes ago
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (5 * 60), // 5 minutes ago
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(120));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([1, 3, 5]));
     let model = {
       stream: stream
     }
@@ -295,33 +185,10 @@ module('Unit | Controller | listen', function(hooks) {
 
   test('hide previous tracks that started more than 1 hour before the start of the current show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
-
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
-    let currentShow = EmberObject.create({
-      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
-    });
-    stream.set('currentShow', currentShow);
-    let currentPlaylistItem = EmberObject.create({
-      catalogEntry: EmberObject.create({
-        composer: {
-          name: 'lorem'
-        }
-      }),
-      startTimeTs: (moment().valueOf() / 1000) - (10 * 60)
-    });
-    stream.set('currentPlaylistItem', currentPlaylistItem);
-    let previous = [
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - ((59 + 16) * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - ((60 + 16) * 60),
-      }),
-      EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - ((61 + 16) * 60),
-      }),
-    ]
-    stream.set('previous', previous);
+    stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
+    stream.set('currentPlaylistItem', createCurrentPlaylistItemWithStartTimeTsValueMeasuredAsMinutesBeforeNow(10));
+    stream.set('previous', createPreviousTracksWithStartTimeTsValuesMeasuredAsMinutesBeforeNow([59 + 16, 60 + 16, 61 + 16]));
     let model = {
       stream: stream
     }

--- a/tests/unit/controllers/listen-test.js
+++ b/tests/unit/controllers/listen-test.js
@@ -23,13 +23,13 @@ module('Unit | Controller | listen', function(hooks) {
     stream.set('currentShow', currentShow);
     let previous = [
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (2 * 60 * 60), // started 2 hours ago
+        startTimeTs: (moment().valueOf() / 1000) - (30 * 60), // started 30 minutes ago
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60), // 3 hours ago
+        startTimeTs: (moment().valueOf() / 1000) - (40 * 60), // 40 minutes ago
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60), // 4 hours ago
+        startTimeTs: (moment().valueOf() / 1000) - (45* 60), // 45 minutes ago
       }),
     ]
     stream.set('previous', previous);
@@ -126,10 +126,10 @@ module('Unit | Controller | listen', function(hooks) {
         startTimeTs: (moment().valueOf() / 1000) - (10 * 60), // track started 10 minutes ago
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60),
+        startTimeTs: (moment().valueOf() / 1000) - (30 * 60),
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60),
+        startTimeTs: (moment().valueOf() / 1000) - (40 * 60),
       }),
     ]
     stream.set('previous', previous);
@@ -160,13 +160,13 @@ module('Unit | Controller | listen', function(hooks) {
     stream.set('currentPlaylistItem', currentPlaylistItem);
     let previous = [
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (2 * 60 * 60),
+        startTimeTs: (moment().valueOf() / 1000) - (30 * 60),
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (3 * 60 * 60),
+        startTimeTs: (moment().valueOf() / 1000) - (31 * 60),
       }),
       EmberObject.create({
-        startTimeTs: (moment().valueOf() / 1000) - (4 * 60 * 60),
+        startTimeTs: (moment().valueOf() / 1000) - (32 * 60),
       }),
     ]
     stream.set('previous', previous);
@@ -182,7 +182,7 @@ module('Unit | Controller | listen', function(hooks) {
     assert.equal(controller.get('playlistHistoryItems').length, 3);
   });
 
-    test('tracks from earlier show should NOT display if show started more than 15 minutes ago and current track started after the first 15 minutes of the show', function(assert) {
+  test('tracks from earlier show should NOT display if show started more than 15 minutes ago and current track started after the first 15 minutes of the show', function(assert) {
     let controller = this.owner.lookup('controller:listen');
 
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
@@ -291,5 +291,46 @@ module('Unit | Controller | listen', function(hooks) {
 
     assert.equal(controller.get('isPlaylistHistoryPreviewStale'), false);
     assert.equal(controller.get('playlistHistoryItems').length, 3); // all 3 tracks from current show should display
+  });
+
+  test('hide previous tracks that started more than 1 hour before the start of the current show', function(assert) {
+    let controller = this.owner.lookup('controller:listen');
+
+    let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
+    let currentShow = EmberObject.create({
+      start_ts: (moment().valueOf() / 1000) - (16  * 60), // show started 16 minutes ago
+    });
+    stream.set('currentShow', currentShow);
+    let currentPlaylistItem = EmberObject.create({
+      catalogEntry: EmberObject.create({
+        composer: {
+          name: 'lorem'
+        }
+      }),
+      startTimeTs: (moment().valueOf() / 1000) - (10 * 60)
+    });
+    stream.set('currentPlaylistItem', currentPlaylistItem);
+    let previous = [
+      EmberObject.create({
+        startTimeTs: (moment().valueOf() / 1000) - ((59 + 16) * 60),
+      }),
+      EmberObject.create({
+        startTimeTs: (moment().valueOf() / 1000) - ((60 + 16) * 60),
+      }),
+      EmberObject.create({
+        startTimeTs: (moment().valueOf() / 1000) - ((61 + 16) * 60),
+      }),
+    ]
+    stream.set('previous', previous);
+    let model = {
+      stream: stream
+    }
+    controller.set('model', model);
+    Ember.inject.service();
+    let service = this.owner.lookup('service:current-stream');
+    service.set('stream', stream);
+
+    assert.equal(controller.get('isPlaylistHistoryPreviewStale'), false);
+    assert.equal(controller.get('playlistHistoryItems').length, 2);
   });
 });


### PR DESCRIPTION
This implements a new rule aimed at preventing the following scenario by hiding any tracks that started more than 1 hour prior to the beginning of the current show:

1. Evenings With Terrence McNight finishes up at 9:00
2. Young Artists Showcase starts at 9:00. For the first 15 minutes, the last 3 tracks from McKnight are shown in the Playlist History Preview (PHP).
3. After 15 minutes, at 9:15, the PHP is hidden because YAS doesn’t have a playlist, per requirements of DSODA-219.
4. No PHP is shown for the rest of YAS
5. At 10:00 Reflections from the Keyboard starts. It also doesn’t have a playlist.
6. FOR THE FIRST 15 MINUTES, THE LAST 3 TRACKS FROM MCKNIGHT ARE SHOWN IN THE PHP, then at 10:15 the PHP is hidden. 

(The Playlist History Preview should be hidden the whole time...)