### PR TITLE
Reconnect to WOMS if connection drops

### DIFF
--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -57,7 +57,7 @@ export default Service.extend({
 
   socketClosedHandler(/*event*/) {
     this.isConnected = false;
-    
+
     if (this.socketRef && !this.initialRetryAttempted) {
       this.initalRetryAttempted = true;
       this.socketReconnect();
@@ -90,7 +90,7 @@ export default Service.extend({
       this.socketRef.reconnect();
     } else {
       this.connectWOMS();
-    }    
+    }
   },
 
   checkConnectionInOneMinute: function() {

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -1,8 +1,11 @@
 import Service from '@ember/service';
 import config from '../config/environment';
 import { inject as service} from '@ember/service';
-import moment from 'moment';
+import ENV from '../config/environment';
+import { run } from '@ember/runloop';
+import moment from "moment";
 
+const isReconnectTimerDisabled = ENV['ember-clock'] && ENV['ember-clock'].disabled;
 export default Service.extend({
   womsHost: config.womsAPI,
   store: service(),
@@ -10,14 +13,23 @@ export default Service.extend({
   websockets: service(),
   socketRef: null,
   currentStream: service(),
+  isConnected: false,
+  initialRetryAttempted: false,
 
   async initializeWOMS() {
+    this.checkConnectionInOneMinute();
+    this.connectWOMS();
+  },
+
+  async connectWOMS() {
     let response = await this.get('currentStream').getStream();
-    this.subscribeWOMS(response)
+    this.subscribeWOMS(response);
   },
 
   subscribeWOMS(response) {
     let stream = response.slug;
+    this.isConnected = false;
+
     const socket = this.websockets.socketFor(`${this.womsHost}?stream=${stream}`);
 
     socket.on('open', this.socketOpenHandler, this);
@@ -28,12 +40,14 @@ export default Service.extend({
   },
 
   socketOpenHandler(/*event*/) {
-    // Runs when the socket is opened
     this.socketRef.send({'data': {'stream': 'wqxr'}}, true);
+    this.isConnected = true;
+    this.initialRetryAttempted = false;
+    run.cancel(this.get('nextCheck'));
+    this.set('nextCheck', null);
   },
 
   socketMessageHandler(event) {
-    // Handles incoming messages
     let data = JSON.parse(event.data);
     if (data.Item && data.Item.metadata) {
       this.processWOMSData(data.Item.metadata);
@@ -42,7 +56,14 @@ export default Service.extend({
   },
 
   socketClosedHandler(/*event*/) {
-    // Runs when the socket is closed
+    this.isConnected = false;
+    
+    if (this.socketRef && !this.initialRetryAttempted) {
+      this.initalRetryAttempted = true;
+      this.socketReconnect();
+    } else {
+      this.checkConnectionInOneMinute();
+    }
   },
 
   processWOMSData(metadata) {
@@ -52,11 +73,36 @@ export default Service.extend({
       if (realStartTime.isValid()) {
         metadata.real_start_time = realStartTime.valueOf() / 1000;
       }
+    }
+
+    if (metadata.start_time) {
       let startTime = moment.tz(metadata.start_time, "America/New_York");
       if (startTime.isValid()) {
         metadata.start_time = startTime.valueOf() / 1000;
       }
     }
+
     this.set('metadata', metadata);
+  },
+
+  socketReconnect: function() {
+    if (this.socketRef) {
+      this.socketRef.reconnect();
+    } else {
+      this.connectWOMS();
+    }    
+  },
+
+  checkConnectionInOneMinute: function() {
+    if (!isReconnectTimerDisabled) {
+      this.set('nextCheck', run.later(this, this.checkConnection, 60 * 1000));
+    }
+  },
+
+  checkConnection: function () {
+    if (this.isConnected == false) {
+      this.socketReconnect();
+    }
+    this.checkConnectionInOneMinute();
   },
 });

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "ember-moment": "7.6.0",
     "ember-qunit": "^4.5.1",
     "ember-resolver": "^5.0.1",
+    "ember-sinon": "^4.1.1",
+    "ember-sinon-qunit": "^4.0.1",
     "ember-source": "~3.9.0",
     "ember-sticky-element": "^0.2.3",
     "ember-svg-jar": "^2.2.3",

--- a/tests/unit/services/woms-test.js
+++ b/tests/unit/services/woms-test.js
@@ -1,0 +1,131 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import sinon from 'sinon';
+
+module('Unit | Service | woms', function(hooks) {
+  setupTest(hooks);
+
+  test('woms exists', function(assert) {
+    let service = this.owner.lookup('service:woms');
+    assert.ok(service);
+  });
+
+  test('it opens a websocket and configures the handlers', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+    let socketRef = {
+      on: function() {}
+    }
+    let originalWebSockets = woms.get('websockets');
+    woms.set('websockets', {
+      socketFor: function() {
+        return socketRef;
+      },
+    });
+
+    sinon.spy(woms.websockets, "socketFor");
+    sinon.spy(socketRef, "on");
+
+    woms.set('socketRef', socketRef);
+    woms.set('isConnected', true);
+
+    woms.subscribeWOMS({ slug: 'wqxr' });
+
+    assert.equal(woms.get('isConnected'), false);
+    assert.equal(socketRef.on.calledThrice, true);
+    assert.equal(woms.websockets.socketFor.calledOnce, true);
+    assert.equal(woms.get('socketRef'), socketRef);
+
+    socketRef.on.restore();
+    woms.websockets.socketFor.restore();
+
+    woms.set('websockets', originalWebSockets);
+  });
+
+  test('it attempts to reconnect to woms backend when the websocket closes', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+    let socketRef = {
+      reconnect: function() {}
+    }
+    sinon.spy(socketRef, "reconnect");
+
+    woms.set('socketRef', socketRef);
+    woms.set('isConnected', true);
+    woms.set('initialRetryAttempted', false);
+
+    woms.socketClosedHandler();
+
+    assert.equal(woms.get('isConnected'), false);
+    assert.equal(socketRef.reconnect.calledOnce, true);
+
+    socketRef.reconnect.restore();
+  });
+
+  test('it does not attempt to reconnect to woms backend when the websocket closes if an initial retry has already been attempted', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+    let socketRef = {
+      reconnect: function() {}
+    }
+    sinon.spy(socketRef, "reconnect");
+
+    woms.set('socketRef', socketRef);
+    woms.set('isConnected', true);
+    woms.set('initialRetryAttempted', true);
+
+    woms.socketClosedHandler();
+
+    assert.equal(woms.get('isConnected'), false);
+    assert.equal(socketRef.reconnect.calledOnce, false);
+
+    socketRef.reconnect.restore();
+  });
+
+  test('it attempts to reconnect when there is no valid socket reference', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+    woms.set('isConnected', false);
+    sinon.spy(woms, "connectWOMS");
+
+    woms.checkConnection();
+
+    assert.equal(woms.get('isConnected'), false);
+    assert.equal(woms.connectWOMS.calledOnce, true);
+
+    woms.connectWOMS.restore();
+  });
+
+  test('it sends a config message to woms backend when the websocket opens', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+    let socketRef = {
+      send: function() {}
+    }
+    sinon.spy(socketRef, "send");
+
+    woms.set('socketRef', socketRef);
+    woms.set('isConnected', false);
+    woms.set('initialRetryAttempted', true);
+
+    woms.socketOpenHandler();
+
+    assert.equal(woms.get('isConnected'), true);
+    assert.equal(woms.get('initialRetryAttempted'), false);
+    assert.equal(socketRef.send.calledOnce, true);
+    assert.equal(socketRef.send.getCall(0).args[0].data.stream, 'wqxr');
+    assert.equal(socketRef.send.getCall(0).args[1], true);
+
+    socketRef.send.restore();
+  });
+
+  test('it stores current track metadata received from woms backend', function(assert) {
+    let woms = this.owner.lookup('service:woms');
+
+    woms.socketMessageHandler({
+      data: '{"Item": {"metadata": {"mm_ensemble1": "Anima Eterna", "start_time": "2019-11-12 13:38:53.868", "david_guid": "{D29A31C7-CCD1-4065-B630-076E4E12254E}", "album": "Beethoven | Complete Symphonies", "mm_reclabel": "Alpha", "catno": "380", "mm_composer1": "Ludwig van Beethoven", "mm_conductor": "Jos van Immerseel, conductor", "length": "654486", "mm_uid": "152565", "real_start_time": "2019-11-12 13:39:32.551", "title": "The Consecration of the House, Op. 124"}}, "ResponseMetadata": {"RequestId": "F8AK56KLQLSKKKIUSE5ODFA1MVVV4KQNSO5AEMVJF66Q9ASUAAJG", "HTTPStatusCode": 200, "HTTPHeaders": {"server": "Server", "date": "Tue, 12 Nov 2019 18:44:06 GMT", "content-type": "application/x-amz-json-1.0", "content-length": "515", "connection": "keep-alive", "x-amzn-requestid": "F8AK56KLQLSKKKIUSE5ODFA1MVVV4KQNSO5AEMVJF66Q9ASUAAJG", "x-amz-crc32": "4043524355"}, "RetryAttempts": 0}}'
+    });
+
+    assert.equal(woms.get('metadata').mm_composer1, 'Ludwig van Beethoven');
+    assert.equal(woms.get('metadata').mm_ensemble1, 'Anima Eterna');
+    assert.equal(woms.get('metadata').title, 'The Consecration of the House, Op. 124');
+    assert.equal(woms.get('metadata').mm_conductor, 'Jos van Immerseel, conductor');
+    assert.equal(woms.get('metadata').real_start_time, 1573583972.551);
+    assert.equal(woms.get('metadata').start_time, 1573583933.868);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,6 +1058,35 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/acorn@^4.0.3":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.5.tgz#e29fdf884695e77be4e99e67d748f5147255752d"
@@ -1549,6 +1578,11 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-to-error@^1.0.0:
   version "1.1.1"
@@ -4082,6 +4116,11 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 diff@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
@@ -5466,6 +5505,25 @@ ember-simple-auth@^1.3.0, ember-simple-auth@^1.8.2:
     ember-fetch "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
     ember-getowner-polyfill "^1.1.0 || ^2.0.0"
     silent-error "^1.0.0"
+
+ember-sinon-qunit@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-sinon-qunit/-/ember-sinon-qunit-4.0.1.tgz#7b8e2fde612406de9a49b13bd85aa8b6997b2074"
+  integrity sha512-qOmcT4InAYOJJ/ypoSYjDJZmTIZpSbTiCHly3U0pE85aPu8PBcNY2ppAXN8ymyZRUV5h5mA956MZZO97kqNjbA==
+  dependencies:
+    broccoli-funnel "^2.0.2"
+    ember-cli-babel "^7.7.3"
+    ember-sinon "^4.1.1"
+
+ember-sinon@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ember-sinon/-/ember-sinon-4.1.1.tgz#ff6db9e3b9548e269386d9efe1c381e165f03ba5"
+  integrity sha512-CmLjy7LGcTw2uP0WdFSPuXYbI7rwB4U/5EOtVU5h2jXtItrnspLIXBL50kigDzwv+lgE8XhfDVPbJ1QMrIXWXg==
+  dependencies:
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^3.0.0"
+    ember-cli-babel "^7.7.3"
+    sinon "^7.4.2"
 
 ember-source-channel-url@^1.1.0:
   version "1.2.0"
@@ -8086,6 +8144,11 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
+
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -8583,6 +8646,11 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+lolex@^4.1.0, lolex@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -9178,6 +9246,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
@@ -9472,9 +9551,8 @@ nypr-audio-services@^0.5.0, nypr-audio-services@nypublicradio/nypr-audio-service
     ember-hifi "^1.11.1"
     ember-responsive "^3.0.0-beta.3"
     ember-simple-auth "^1.3.0"
-    eslint-plugin-ember "^5.0.0"
-    liquid-fire "^0.31.0"
-    nypr-metrics "0.7.1"
+    liquid-fire "^0.29.1"
+    nypr-metrics "^0.5.0"
     nypr-ui "^0.5.0"
 
 "nypr-design-system@https://github.com/nypublicradio/nypr-design-system.git#88e3366":
@@ -10043,6 +10121,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -11206,6 +11291,19 @@ simple-html-tokenizer@^0.3.0:
   resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.3.0.tgz#9b8b5559d80e331a544dd13dd59382e5d0d94411"
   integrity sha1-m4tVWdgOMxpUTdE91ZOC5dDZRBE=
 
+sinon@^7.4.2:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -11738,7 +11836,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -12187,7 +12285,7 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
This PR adds logic to reconnect to WOMS if the connection drops due to a timeout, network issue, etc.

Reconnect logic works as follows:
1. When connection drops, immediately attempt to reconnect once. The most likely scenario here is a timeout because no pushes have been received in a while (I'm seeing a 10-minute inactivity timeout).
2. If this connection attempt fails, fall back on a retry every 60 seconds. This avoids repeated, immediate attempts in the event that the WOMS backend is down or refusing connections.

I also added test coverage for the WOMS service.

`isReconnectTimerDisabled` disables the reconnect timer during tests because if the timer is set on the run loop, the tests don't work.