### PR TITLE
Onboard Message tweaks

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import { set } from "@ember/object";
 import { computed } from '@ember/object';
+import { reads } from '@ember/object/computed';
 import move from 'ember-animated/motions/move';
 import { easeInAndOut } from 'ember-animated/easings/cosine';
 
@@ -10,10 +11,15 @@ export default Controller.extend({
   hifi           : service(),
   cookies        : service(),
   currentStream  : service(),
+  fastboot       : service(),
+  isFastBoot     : reads('fastboot.isFastBoot'),
   links: [ { 'href': null, 'nav-slug': 'listen', 'title': 'Listen'}, { 'href': null, 'nav-slug': 'playlist-history', 'title': 'Playlist History'} ],
 
   showPlayer: true,
   showOnboardMessage: computed('closed', function() {
+    if (this.isFastBoot) {
+      return this.get('fastboot.request.cookies.showOnboardMessage') === undefined;
+    }
     return !this.cookies.exists('showOnboardMessage');
   }),
 

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import config from '../config/environment';
 import { inject as service} from '@ember/service';
+import { reads } from '@ember/object/computed';
 import ENV from '../config/environment';
 import { run } from '@ember/runloop';
 import moment from "moment";
@@ -15,8 +16,13 @@ export default Service.extend({
   currentStream: service(),
   isConnected: false,
   initialRetryAttempted: false,
+  fastboot: service(),
+  isFastBoot: reads('fastboot.isFastBoot'),
 
   async initializeWOMS() {
+    if (this.isFastBoot) {
+      return;
+    }
     this.checkConnectionInOneMinute();
     this.connectWOMS();
   },

--- a/app/templates/components/onboard-message.hbs
+++ b/app/templates/components/onboard-message.hbs
@@ -1,6 +1,6 @@
 <a href="#" class="onboard-close" {{action 'hideOnboardMessage'}} data-test-element="close">{{svg-jar "close"}}</a>
 <div class="onboard-title" data-test-element="title">Welcome to a New WQXR</div>
-<div class="onboard-body" data-test-element="body">We launched an alternative experience of WQXR.org to highlight the classical programming that our listeners love, and to try out new features. Help us improve by <a class="onboard-feedback" href=" https://www.surveymonkey.com/r/XQQSB68" data-test-element="feedback">sharing your feedback</a>.</div>
+<div class="onboard-body" data-test-element="body">We're developing an alternative experience of WQXR.org to highlight the classical programming that our listeners love, and to try out new features. Help us improve by <a class="onboard-feedback" href=" https://www.surveymonkey.com/r/XQQSB68" data-test-element="feedback">sharing your feedback</a>.</div>
 <div class="onboard-buttons">
 	<a href="https://www.wqxr.org" class="onboard-old-wqxr-button" target="_blank" data-test-element="old-wqxr-site">Go Back to Old WQXR.org</a>
 	<a href="#" class="onboard-jukebox-button" {{action 'hideOnboardMessage'}} data-test-element="take-a-look">Thanks, I'll Take A Look</a>

--- a/tests/integration/components/onboard-message-test.js
+++ b/tests/integration/components/onboard-message-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | onboard-message', function(hooks) {
     `);
 
     assert.dom('[data-test-element="title"]').hasText('Welcome to a New WQXR')
-    assert.dom('[data-test-element="body"]').hasText('We launched an alternative experience of WQXR.org to highlight the classical programming that our listeners love, and to try out new features. Help us improve by sharing your feedback.')
+    assert.dom('[data-test-element="body"]').hasText('We\'re developing an alternative experience of WQXR.org to highlight the classical programming that our listeners love, and to try out new features. Help us improve by sharing your feedback.')
     assert.dom('[data-test-element="old-wqxr-site"]').hasText('Go Back to Old WQXR.org')
     assert.dom('[data-test-element="take-a-look"]').hasText('Thanks, I\'ll Take A Look')
   });


### PR DESCRIPTION
1. Prevent brief rendering of onboard message when page is refreshed by reading the cookie setting from the appropriate location when in Fastboot mode.
2. Fix some copy
3. Turn off WOMS when in Fastboot mode (this isn't really related, but since I was dealing with Fastboot issues, I added this in)