### PR TITLE
DSODA-118 return false for `showOnboardMessage` in Fastboot

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -18,7 +18,7 @@ export default Controller.extend({
   showPlayer: true,
   showOnboardMessage: computed('closed', function() {
     if (this.isFastBoot) {
-      return this.get('fastboot.request.cookies.showOnboardMessage') === undefined;
+      return false;
     }
     return !this.cookies.exists('showOnboardMessage');
   }),


### PR DESCRIPTION
I couldn't figure out why Fastboot isn't reading the cookie indicating whether to display the on boarding message, so to prevent showing the message when it shouldn't be displayed in Fastboot-rendered pages, this PR just says to not display the message at all in Fastboot.

