### PR TITLE
Bkammin/visual polish

### DIFF
--- a/app/components/horizontal-nav/template.hbs
+++ b/app/components/horizontal-nav/template.hbs
@@ -3,7 +3,7 @@
     <ul class="horizontal-nav__list">
       {{#each parsedLinks as |link index|}}
         <li class={{if (eq index activeTabIndex) "is-active horizontal-nav__list-item" "horizontal-nav__list-item"}}>
-          {{link-to link.title link.nav-slug classNames="horizontal-nav__link"}}
+          {{link-to link.title link.route classNames="horizontal-nav__link"}}
         </li>
       {{/each}}
     </ul>

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -13,7 +13,7 @@ export default Controller.extend({
   currentStream  : service(),
   fastboot       : service(),
   isFastBoot     : reads('fastboot.isFastBoot'),
-  links: [ { 'href': null, 'nav-slug': 'listen', 'title': 'Listen'}, { 'href': null, 'nav-slug': 'playlist-history', 'title': 'Playlist History'} ],
+  links: [ { 'href': null, 'nav-slug': 'listen', 'route': 'listen', 'title': 'Listen'}, { 'href': null, 'nav-slug': 'playlist-history', 'route': 'playlist-history-today', 'title': 'Playlist History'} ],
 
   showPlayer: true,
   showOnboardMessage: computed('closed', function() {

--- a/app/helpers/format-start-time.js
+++ b/app/helpers/format-start-time.js
@@ -2,11 +2,11 @@ import { helper } from '@ember/component/helper';
 import moment from 'moment';
   
 export function formatStartTime(timestamp) {
-  let momentStartTime = moment(timestamp,'YYYY-MM-DDTHH:mm:ss');
+  let momentStartTime = moment(timestamp,'YYYY-MM-DDTHH:mm:ss', true);
   if (momentStartTime.isValid()) {
     return momentStartTime.format('h:mm A');
   } else {
-    momentStartTime = moment(timestamp,'hh:mm A');
+    momentStartTime = moment(timestamp,'hh:mm A', true);
     if (momentStartTime.isValid()) {
       return momentStartTime.format('h:mm A');
     }

--- a/app/router.js
+++ b/app/router.js
@@ -9,7 +9,7 @@ const Router = Ember.Router.extend({
 Router.map(function() {
   this.route('listen');
   this.route('playlist-history', { path: 'playlist-history/:year/:month/:day' });
-  this.route('playlist-history');
+  this.route('playlist-history-today', { path: 'playlist-history'});
 });
 
 export default Router;

--- a/app/routes/playlist-history-today.js
+++ b/app/routes/playlist-history-today.js
@@ -1,0 +1,5 @@
+import PlaylistHistoryRoute from './playlist-history';
+
+export default PlaylistHistoryRoute.extend({
+	templateName: 'playlist-history'
+});

--- a/app/templates/listen.hbs
+++ b/app/templates/listen.hbs
@@ -82,7 +82,7 @@
                 />
               {{/each}}
             </div>
-            <a href="/playlist-history" class="view-full-playlist-history-button">VIEW FULL PLAYLIST HISTORY</a>
+            {{#link-to "playlist-history-today" class="view-full-playlist-history-button"}}VIEW FULL PLAYLIST HISTORY{{/link-to}}
           </div>
         {{/if}}
       {{/if}}

--- a/app/templates/playlist-history.hbs
+++ b/app/templates/playlist-history.hbs
@@ -5,15 +5,25 @@
 
 <div class="playlist-history-display">
   <div class="date-selector">
-    <a class="date-selector-back" href={{playlist-history-href model.date -1}}>
+    {{#link-to "playlist-history"
+              (moment-format (moment-add model.date -1 precision='days') 'YYYY')
+              (moment-format (moment-add model.date -1 precision='days') 'MM')
+              (moment-format (moment-add model.date -1 precision='days') 'DD')
+              class="date-selector-back"
+    }}
       {{svg-jar "left-arrow"}}
       <span>{{formatted-picker-date model.date -1}}</span>
-    </a>
+    {{/link-to}}
     {{#if (can-show-schedule-for-date model.date 1)}}
-    <a class="date-selector-forward" href={{playlist-history-href model.date 1}}>
-      <span>{{formatted-picker-date model.date 1}}</span>
-      {{svg-jar "left-arrow"}}
-    </a>
+      {{#link-to "playlist-history"
+                (moment-format (moment-add model.date 1 precision='days') 'YYYY')
+                (moment-format (moment-add model.date 1 precision='days') 'MM')
+                (moment-format (moment-add model.date 1 precision='days') 'DD')
+                class="date-selector-forward"
+      }}
+        <span>{{formatted-picker-date model.date 1}}</span>
+        {{svg-jar "left-arrow"}}
+      {{/link-to}}
     {{/if}}
   </div>
 

--- a/tests/unit/routes/playlist-history-today-test.js
+++ b/tests/unit/routes/playlist-history-today-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | playlist-history-today', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:playlist-history-today');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
1. fix a date formatting issue where some tracks in the Playlist History incorrectly listed `12:00 AM` as their start time.
2. fix routing and use proper ember linking pattern to avoid a hard refresh (and thus interrupted playback) when user clicks back/forward in time on the playlist history route.