### PR TITLE
Bkammin/dsoda 284 switch php api

### DIFF
--- a/app/adapters/stream.js
+++ b/app/adapters/stream.js
@@ -2,6 +2,7 @@ import config from 'ember-get-config';
 import DS from 'ember-data';
 import rsvp from 'rsvp';
 import fetch from 'fetch';
+import moment from 'moment';
 
 const json = r => r.json();
 
@@ -18,9 +19,11 @@ export default DS.JSONAPIAdapter.extend({
   // BEGIN-SNIPPET stream-find-record
   findRecord(store, type, id/*, snapshot*/) {
     let base = `${this.host}/${this.namespace}`;
+    let date = moment.tz(moment(), "America/New_York").format('YYYY/MMM/DD').toLowerCase();
     return rsvp.hash({
       stream: fetch(`${base}/list/streams/${id}/`).then(json),
       whatsOn: fetch(`${base}/whats_on/${id}/3/`).then(json),
+      schedule: fetch(`${base}/playlist-daily/${id}/${date}/`).then(json),
     });
   }
   // END-SNIPPET

--- a/app/controllers/listen.js
+++ b/app/controllers/listen.js
@@ -58,7 +58,7 @@ export default Controller.extend({
       let currentTrackStartTime = moment(this.currentStream.trackStartTimeTs * 1000).format("hh:mm A");
       return this.model.stream.previous.filter( (track) => {
         return track.startTimeTs >= showStartTimeTs &&
-               track.time != currentTrackStartTime;;
+               track.time != currentTrackStartTime;
       }).slice(0,3);
     }
 

--- a/app/serializers/stream.js
+++ b/app/serializers/stream.js
@@ -39,6 +39,6 @@ export default StreamSerializer.extend({
       return a.startTimeTs < b.startTimeTs ? 1 : -1;
     })
 
-    return newPlaylist.slice(0,3);
+    return newPlaylist.slice(0,4);
   },
 });

--- a/app/serializers/stream.js
+++ b/app/serializers/stream.js
@@ -1,0 +1,44 @@
+import StreamSerializer from 'nypr-publisher-lib/serializers/stream';
+import moment from 'moment';
+
+export default StreamSerializer.extend({
+  normalizeFindRecordResponse(store, modelClass, payload, id, requestType) {
+    let response = this._super(store, modelClass, payload, id, requestType);
+    response.data.attributes.previous = this._getPlaylistItems(payload.schedule);
+    return response;
+  },
+
+  _getPlaylistItems(schedule) {
+    var newPlaylist = []
+
+    if (!schedule.events) {
+      return newPlaylist;
+    }
+
+    schedule.events.forEach(function(event) {
+      if (event.playlists) {
+        event.playlists.forEach(function(playlist) {
+          if (playlist.played) {
+            newPlaylist.push.apply(newPlaylist, playlist.played);
+          }
+        });
+      }
+    });
+
+    newPlaylist.forEach(function(item) {
+      let momentTime = moment(item.time,'hh:mm A', true);
+      if (momentTime.isValid()) {
+        item.startTimeTs = momentTime.valueOf() / 1000;
+        item.startTime = momentTime.format('YYYY-MM-DDTHH:mm:ss');
+        item.catalogEntry = item.info;
+        delete item['info'];
+      }
+    })
+
+    newPlaylist.sort(function(a, b) {
+      return a.startTimeTs < b.startTimeTs ? 1 : -1;
+    })
+
+    return newPlaylist.slice(0,3);
+  },
+});

--- a/app/services/current-stream.js
+++ b/app/services/current-stream.js
@@ -58,7 +58,7 @@ export default Service.extend({
   },
 
   async refreshStream() {
-    let stream = await this.store.findRecord('stream', this.slug);
+    let stream = await this.store.findRecord('stream', this.slug, {reload: true});
     let show   = await this.store.findRecord('show', stream.currentShow.group_slug);
     stream.set('about', show.about);
     this.set('stream', stream);

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -15,6 +15,7 @@ export default Service.extend({
   socketRef: null,
   currentStream: service(),
   isConnected: false,
+  firstUpdateReceived: false,
   initialRetryAttempted: false,
   fastboot: service(),
   isFastBoot: reads('fastboot.isFastBoot'),
@@ -56,6 +57,7 @@ export default Service.extend({
   socketMessageHandler(event) {
     let data = JSON.parse(event.data);
     if (data.Item && data.Item.metadata) {
+      this.firstUpdateReceived = true;
       this.processWOMSData(data.Item.metadata);
       this.get('currentStream').refreshStream();
     }

--- a/app/templates/listen.hbs
+++ b/app/templates/listen.hbs
@@ -50,7 +50,7 @@
     </div>
   </div>
 
-  {{#if (or (or this.currentStream.composerName this.currentStream.trackTitle)
+  {{#liquid-if (or (or this.currentStream.composerName this.currentStream.trackTitle)
             (and (not this.isPlaylistHistoryPreviewStale) this.playlistHistoryItems))
   }}
     <div class="playlist-history">
@@ -87,7 +87,7 @@
         {{/if}}
       {{/if}}
     </div>
-  {{/if}}
+  {{/liquid-if}}
 </div>
 
 {{outlet}}

--- a/tests/unit/controllers/listen-test.js
+++ b/tests/unit/controllers/listen-test.js
@@ -48,12 +48,17 @@ function createWomsMetadataWithStartTimeTsValueMeasuredAsMinutesBeforeNow(startT
 module('Unit | Controller | listen', function(hooks) {
   setupTest(hooks);
 
+  //let womsService = this.owner.lookup('service:woms').set('firstUpdateReceived', true);
+
+  //womsService.set('firstUpdateReceived', true);
+
   test('it exists', function(assert) {
     let controller = this.owner.lookup('controller:listen');
     assert.ok(controller);
   });
 
   test('playlist history should not be stale if show started less than 15 minutes ago', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(14));
@@ -68,6 +73,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('no current track - playlist history should be stale if there are no previous playlist items', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(60));
@@ -81,6 +87,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('no tracks from earlier show should display if show started more than 15 minutes ago and there are no tracks from current show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -95,6 +102,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('playlist history should  only display tracks for current show if first track for show started more than 15 minutes after start of show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -109,6 +117,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('playlist history should  only display previous tracks from earlier show if first track for show started less than 15 minutes after start of show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -123,6 +132,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('tracks from earlier show should display if show started more than 15 minutes ago and current track started within first 15 minutes show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -143,6 +153,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('tracks from earlier show should NOT display if show started more than 15 minutes ago and current track started after the first 15 minutes of the show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -163,6 +174,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
 	test('playlist history should not be stale if all previous tracks are from the current show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(120));
@@ -183,6 +195,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('no current track - playlist history should not be stale if all previous tracks are from the current show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(120));
@@ -197,6 +210,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('hide previous tracks that started more than 1 hour before the start of the current show', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(16));
@@ -217,6 +231,7 @@ module('Unit | Controller | listen', function(hooks) {
   });
 
   test('previous is undefined', function(assert) {
+    this.owner.lookup('service:woms').set('firstUpdateReceived', true);
     let controller = this.owner.lookup('controller:listen');
     let stream = run(() => this.owner.lookup('service:store').createRecord('stream'));
     stream.set('currentShow', createCurrentSHowWithStartTimeTsValueMeasuredAsMinutesBeforeNow(60));

--- a/tests/unit/serializers/stream-test.js
+++ b/tests/unit/serializers/stream-test.js
@@ -1,0 +1,23 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Serializer | stream', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let serializer = store.serializerFor('stream');
+
+    assert.ok(serializer);
+  });
+
+  test('it serializes records', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let record = store.createRecord('stream', {});
+
+    let serializedRecord = record.serialize();
+
+    assert.ok(serializedRecord);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9538,7 +9538,6 @@ nypr-ads@^0.2.0:
 
 nypr-audio-services@^0.5.0, nypr-audio-services@nypublicradio/nypr-audio-services#jkeen/upgrades:
   version "0.5.9"
-  uid "27ee78c34df574c6c2f0406096c84f80d7c5cf48"
   resolved "https://codeload.github.com/nypublicradio/nypr-audio-services/tar.gz/27ee78c34df574c6c2f0406096c84f80d7c5cf48"
   dependencies:
     ember-cli-babel "^6.6.0"
@@ -9551,8 +9550,9 @@ nypr-audio-services@^0.5.0, nypr-audio-services@nypublicradio/nypr-audio-service
     ember-hifi "^1.11.1"
     ember-responsive "^3.0.0-beta.3"
     ember-simple-auth "^1.3.0"
-    liquid-fire "^0.29.1"
-    nypr-metrics "^0.5.0"
+    eslint-plugin-ember "^5.0.0"
+    liquid-fire "^0.31.0"
+    nypr-metrics "0.7.1"
     nypr-ui "^0.5.0"
 
 "nypr-design-system@https://github.com/nypublicradio/nypr-design-system.git#88e3366":


### PR DESCRIPTION
This PR attempts to sync up the playlist history preview with the WOMS-driven current track metadata by:

1. Using the `playlist-daily` API end point instead of `what_on` for previous track information. This requires an additional network call, but gets around caching issues related to `whats_on`. Accomplished by adding the api call to `app/adapters/stream` and replacing `whats_on`'s previous tracks with tracks from `playlist-daily` in `app/serializers/stream`.
2. Checking to ensure current track is not displayed in playlist history preview
3. On page load, delaying display of entire current track+playlist history preview until WOMS has pushed the current track metadata.
4. Hiding playlist history preview in Fastboot since Fastboot doesn't have access to WOMS.
5. Add an animation to smooth out the initial display of current track+playlist history preview once initial WOMS metadata is received.