### PR TITLE
Adjust positioning calculations for toggle box

### DIFF
--- a/app/styles/components/_toggle-box.scss
+++ b/app/styles/components/_toggle-box.scss
@@ -27,6 +27,7 @@ $arrow_width: 8px;
 .toggle-box__dropdown {
   border-radius: 4px;
   padding: 19px 24px;
+  max-width: 300px;
 }
 
 // Default dark theme
@@ -50,11 +51,11 @@ $arrow_width: 8px;
   }
 
   &[data-h-pos="right"]::before {
-    right: 30%;
+    right: 33%;
   }
 
   &[data-h-pos="left"]::before {
-    left: 30%;
+    left: 33%;
   }
 
   &[data-h-pos="center"]::before {

--- a/app/utils/toggle-box-positioner.js
+++ b/app/utils/toggle-box-positioner.js
@@ -1,5 +1,7 @@
 import defaultCalculatePosition from 'ember-basic-dropdown/utils/calculate-position';
 
+const ARROW_WIDTH = 16;
+
 export default function calculatePosition(trigger, content, _destination, ref) {
   let icon = trigger.querySelector('.o-icon--caret svg')
   if (icon) {
@@ -12,6 +14,7 @@ export default function calculatePosition(trigger, content, _destination, ref) {
 
   let {
     left: triggerLeft,
+    width: triggerWidth,
   } = trigger.getBoundingClientRect();
 
   let {
@@ -28,10 +31,10 @@ export default function calculatePosition(trigger, content, _destination, ref) {
   obj['style']['top'] = obj['style']['top'] + bottomOffset;
 
   if (horizontalPosition == 'left') {
-    obj['style']['left'] = Math.abs(triggerLeft - (contentWidth / 3) + 8);
+    obj['style']['left'] = Math.abs(triggerLeft - (contentWidth / 3) - (ARROW_WIDTH / 2) + (triggerWidth / 2) + 1);
   }
   else if (horizontalPosition == 'center') {
-     obj['style']['left'] = Math.abs(triggerLeft - contentWidth / 2 + 9);
+     obj['style']['left'] = Math.abs(triggerLeft - contentWidth / 2 - (ARROW_WIDTH / 2) + (triggerWidth / 2) + 1);
   }
 
   // Apply ember-basic-dropdown's repositioning


### PR DESCRIPTION
I had some errors in my initial positioning so it would vary based on the width of the thing -- the CSS had the arrow being positioned at 30%, the js positioning calculation was just dividing by 3. Also the width of the carets were not being accounted for properly. This corrects that and should line them up exactly.

https://jira.wnyc.org/browse/DSODA-224

