### PR TITLE
Frontend model improvements

### DIFF
--- a/app/models/airing.js
+++ b/app/models/airing.js
@@ -11,7 +11,7 @@ export default DS.Model.extend({
   showSlug: attr(),
   showTitle: attr(),
   showId: attr(),
-  show: belongsTo({ async: false }),
+  show: belongsTo({ async: true }),
   playlistDaily: belongsTo({ async: false }),
   // episode: belongsTo('story', { async: false }),
   tracks: hasMany('tracks', { async: false, inverse: 'airing' }),

--- a/app/serializers/playlist-daily.js
+++ b/app/serializers/playlist-daily.js
@@ -1,6 +1,8 @@
 import ApplicationSerializer from './application';
 import transformAttributes from '../utils/transform-attributes';
 import generateTrackUniqueId from '../utils/generate-track-unique-id';
+import generateAiringUniqueId from '../utils/generate-airing-unique-id';
+
 import moment from 'moment';
 import { get } from '@ember/object';
 
@@ -81,10 +83,11 @@ export default ApplicationSerializer.extend({
     let included = [];
 
     let airings = events.map(event => {
+      let airingAttrs = transformAttributes(event, airingAttributeTransform);
       let airing = {
-        id: event.id,
+        id: generateAiringUniqueId(airingAttrs),
         type: 'airing',
-        attributes: transformAttributes(event, airingAttributeTransform)
+        attributes: airingAttrs
       };
 
       if (event.playlist && event.playlist.length > 0) {
@@ -92,6 +95,12 @@ export default ApplicationSerializer.extend({
 
         if (tracks.length > 0) {
           airing.relationships = {
+            show: {
+              data: {
+                id: airingAttrs.show_slug,
+                type: 'show',
+              }
+            },
             tracks: {
               data: tracks.map(t => ({ id: t.id, type: t.type }))
             }

--- a/app/services/now-playing.js
+++ b/app/services/now-playing.js
@@ -58,6 +58,17 @@ export default Service.extend({
   async load() {
     let nowPlaying = await this.store.queryRecord('whats-on', {stream: this.slug});
     this.set('track', nowPlaying.tracks.firstObject);
+    this.connectTrackAndShow();
+  },
+
+  connectTrackAndShow() {
+    // This will be obsolted when tracks from woms include show information
+    // and we can update the serializer to do this processing
+    if (this.track && this.show) {
+      if (!this.track.show) {
+        this.track.set('show', this.show);
+      }
+    }
   },
 
   async getStream() {
@@ -78,6 +89,7 @@ export default Service.extend({
     } else {
       this.set('show', undefined);
     }
+    this.connectTrackAndShow();
 
     return stream;
   },

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -14,6 +14,7 @@ export default Service.extend({
   hifi: service(),
   nowPlaying: service(),
   websockets: service(),
+  router: service(),
   socketRef: null,
   isConnected: false,
   firstUpdateReceived: false,
@@ -65,8 +66,7 @@ export default Service.extend({
       this.set('lastMessage', data);
       this.processWomsData(data);
       let owner = getOwner(this);
-      let applicationController = owner.lookup('controller:application');
-      let currentRoute = get(applicationController, 'currentRouteName');
+      let currentRoute = this.router.currentRouteName;
       let route = owner.lookup(`route:${currentRoute}`);
       route.refresh();
     }

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -3,7 +3,6 @@ import config from '../config/environment';
 import { getOwner } from '@ember/application';
 import { inject as service } from '@ember/service';
 import { reads } from '@ember/object/computed';
-import { get } from '@ember/object';
 import ENV from '../config/environment';
 import { run } from '@ember/runloop';
 

--- a/app/utils/generate-airing-unique-id.js
+++ b/app/utils/generate-airing-unique-id.js
@@ -1,0 +1,7 @@
+import moment from 'moment';
+export default function generateAiringUniqueId(airingAttrs) {
+  let startDate = moment(airingAttrs.start_time);
+  let endDate = moment(airingAttrs.end_time);
+
+  return `a_${airingAttrs.show_id}_${startDate.format('YYYY-MM-DD_hh:mm')}_${endDate.format('YYYY-MM-DD_hh:mm')}`
+}

--- a/tests/unit/services/woms-test.js
+++ b/tests/unit/services/woms-test.js
@@ -132,6 +132,9 @@ module('Unit | Service | woms', function(hooks) {
     let socketRef = {
       off: function() {},
     }
+    woms.set('router', {
+      currentRouteName: 'listen'
+    })
     woms.set('socketRef', socketRef);
 
     let routeStub = {
@@ -141,9 +144,6 @@ module('Unit | Service | woms', function(hooks) {
     let womsOwner = getOwner(woms);
 
     let stub = sinon.stub(womsOwner, 'lookup')
-    stub.withArgs('controller:application').returns({
-      currentRouteName: 'listen'
-    });
     stub.withArgs('route:listen').returns(routeStub);
     stub.callThrough()
 

--- a/tests/unit/utils/generate-airing-unique-id-test.js
+++ b/tests/unit/utils/generate-airing-unique-id-test.js
@@ -1,0 +1,18 @@
+import generateAiringUniqueId from 'nypr-jukeboxes/utils/generate-airing-unique-id';
+import { module, test } from 'qunit';
+import moment from 'moment';
+
+module('Unit | Utility | generate-airing-unique-id', function() {
+
+  test('it works', function(assert) {
+    moment.tz.setDefault("America/New_York");
+
+    let result = generateAiringUniqueId({
+      show_id     : '124',
+      start_time  : "2019-12-01T12:00:00+00:00",
+      end_time    : "2019-12-01T13:00:00+00:00",
+    });
+
+    assert.equal(result, 'a_124_2019-12-01_07:00_2019-12-01_08:00');
+  });
+});


### PR DESCRIPTION
I think the reason that one track was appearing out of order is due to the way the frontend models were getting created. The airings were being created by using the `event_id` which was not unique across days, meaning that when navigating back in time or when another show came up naturally, the previous shows tracks would sometimes still be correlated to the current airing. 

This makes sure each airing's id is actually unique, so that each playlist is correlated correctly with a single show's airing.