### PR TITLE
Favor publisher playlist data

### DIFF
--- a/app/services/now-playing.js
+++ b/app/services/now-playing.js
@@ -131,13 +131,13 @@ export default Service.extend({
     // load the stream, which will load the current show
     await this.getStream()
 
+    let whatsOn = await this.store.queryRecord('whats-on', {stream: this.slug});
+    this.updateWhatsOn(whatsOn);
+
     // Load playlist daily to populate schedule models on frontend
     let serverDate = moment.tz(moment(), "America/New_York")
     await this.loadSchedule(serverDate);
     await this.updateSchedule()
-
-    let whatsOn = await this.store.queryRecord('whats-on', {stream: this.slug});
-    this.updateWhatsOn(whatsOn);
   },
 
   updateWhatsOn(whatsOn) {

--- a/app/services/now-playing.js
+++ b/app/services/now-playing.js
@@ -100,6 +100,12 @@ export default Service.extend({
     }
   },
 
+  async refreshNowPlayingFromPublisher() {
+    /* 2020-04-21 With WOMS mainly running off of nexgen these days, most of the track data is missing composers. While we agreed that it should not be a frontend task to decide which data source is correct/valid and that our APIs should be able to be trusted, until we can fix the music master link with WOMs (the real solution) we determined the best workaround is to call publisher's crusty playlist API to fill in the missing data after every WOMs update. This temporarily makes WOMs more of a service that says "hey, there's an update available! Go find out what it is" rather than telling us what that update is. *Sad trombone* -JK */
+
+    return await this.loadSchedule(moment.tz(moment(), "America/New_York"))
+  },
+
   async loadSchedule(serverDate) {
     await this.store.findRecord('playlist-daily', `wqxr/${serverDate.format('YYYY/MMM/DD').toLowerCase()}`, { reload: true });
     this.set('lastScheduleDate', serverDate.format('YYYY/MMM/DD'));

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -82,6 +82,7 @@ export default Service.extend({
     // This will update the existing model if it exists, adds it if it doesn't
     let model = this.store.push(normalized);
     this.nowPlaying.updateWhatsOn(model);
+    this.nowPlaying.refreshNowPlayingFromPublisher();
   },
 
   socketClosedHandler(/*event*/) {


### PR DESCRIPTION
I added a comment to the code with this, but it can be repeated here: 

With WOMS mainly running off of nexgen these days, most of the track data is missing composers. While we agreed that it should not be a frontend task to decide which data source is correct/valid and that our APIs should be able to be trusted, until we can fix the music master link with WOMs (the real solution) we determined the best workaround is to call publisher's crusty playlist API to fill in the missing data after every WOMs update. This temporarily makes WOMs more of a service that says "hey, there's an update available! Go find out what it is" rather than telling us what that update is. *Sad trombone* 