### PR TITLE
Merge incomplete track data from woms with local data

### DIFF
--- a/app/serializers/whats-on.js
+++ b/app/serializers/whats-on.js
@@ -3,7 +3,7 @@ import ApplicationSerializer from './application';
 export default ApplicationSerializer.extend({
 
   _normalizeResponse(store, primaryModelClass, payload /*, id, requestType, isSingle */) {
-    /* 2020-04-21 HACK: we should be able to delete this method entirely after this is fixed: https://jira.wnyc.org/browse/DSODA-375
+    /* 2020-04-21 TODO: we should be able to delete this method entirely after this is fixed: https://jira.wnyc.org/browse/DSODA-375
 
     This crudely merges incoming (and mostly likely incomplete) records from woms with existing (mostly likely more complete) records we have in the ember-data store from publisher. This prevents the UI from flashing needlessly when records get updated with incorrect data, rendered, corrected, and rendered.
 

--- a/app/serializers/whats-on.js
+++ b/app/serializers/whats-on.js
@@ -1,4 +1,32 @@
 import ApplicationSerializer from './application';
+
 export default ApplicationSerializer.extend({
+
+  _normalizeResponse(store, primaryModelClass, payload /*, id, requestType, isSingle */) {
+    /* 2020-04-21 HACK: we should be able to delete this method entirely after this is fixed: https://jira.wnyc.org/browse/DSODA-375
+
+    This crudely merges incoming (and mostly likely incomplete) records from woms with existing (mostly likely more complete) records we have in the ember-data store from publisher. This prevents the UI from flashing needlessly when records get updated with incorrect data, rendered, corrected, and rendered.
+
+    It works and I hate it. - JK*/
+
+    if (payload && payload.included) {
+      payload.included.forEach(record => {
+        if (record.type == 'track') {
+          let existingTrack = store.peekRecord('track', record.id)
+          if (existingTrack) {
+            record.attributes.title     = record.attributes.title     || existingTrack.trackTitle;
+            record.attributes.composer  = record.attributes.composer  || existingTrack.composerName;
+            record.attributes.conductor = record.attributes.conductor || existingTrack.conductorName;
+            record.attributes.catno     = record.attributes.catno     || existingTrack.catno;
+            record.attributes.album     = record.attributes.album     || existingTrack.albumName;
+            record.attributes.ensemble  = record.attributes.ensemble  || existingTrack.ensembleName;
+            record.attributes.reclabel  = record.attributes.reclabel  || existingTrack.reclabel;
+          }
+        }
+      })
+    }
+
+    return this._normalizeDocumentHelper(payload);
+  },
 
 });

--- a/app/services/now-playing.js
+++ b/app/services/now-playing.js
@@ -101,7 +101,10 @@ export default Service.extend({
   },
 
   async refreshNowPlayingFromPublisher() {
-    /* 2020-04-21 With WOMS mainly running off of nexgen these days, most of the track data is missing composers. While we agreed that it should not be a frontend task to decide which data source is correct/valid and that our APIs should be able to be trusted, until we can fix the music master link with WOMs (the real solution) we determined the best workaround is to call publisher's crusty playlist API to fill in the missing data after every WOMs update. This temporarily makes WOMs more of a service that says "hey, there's an update available! Go find out what it is" rather than telling us what that update is. *Sad trombone* -JK */
+    /* 2020-04-21 With WOMS mainly running off of nexgen these days, most of the track data is missing composers. While we agreed that it should not be a frontend task to decide which data source is correct/valid and that our APIs should be able to be trusted, until we can fix the music master link with WOMs (the real solution) we determined the best workaround is to call publisher's crusty playlist API to fill in the missing data after every WOMs update. This temporarily makes WOMs more of a service that says "hey, there's an update available! Go find out what it is" rather than telling us what that update is. Sad trombone* -JK
+
+    We should be able to stop this once this gets fixed: https://jira.wnyc.org/browse/DSODA-375
+    */
 
     return await this.loadSchedule(moment.tz(moment(), "America/New_York"))
   },
@@ -137,13 +140,15 @@ export default Service.extend({
     // load the stream, which will load the current show
     await this.getStream()
 
-    let whatsOn = await this.store.queryRecord('whats-on', {stream: this.slug});
-    this.updateWhatsOn(whatsOn);
-
-    // Load playlist daily to populate schedule models on frontend
+    // Load playlist daily to populate schedule models and tracks on frontend
     let serverDate = moment.tz(moment(), "America/New_York")
     await this.loadSchedule(serverDate);
     await this.updateSchedule()
+
+    // Load from WOMS rest endpoint, gettings tracks that are not in publisher yet, knowing that
+    // incomplete data will be merged (thanks to some unsightly serializer hacks in /serializers/whats-on)
+    let whatsOn = await this.store.queryRecord('whats-on', {stream: this.slug});
+    this.updateWhatsOn(whatsOn);
   },
 
   updateWhatsOn(whatsOn) {

--- a/app/services/now-playing.js
+++ b/app/services/now-playing.js
@@ -103,7 +103,7 @@ export default Service.extend({
   async refreshNowPlayingFromPublisher() {
     /* 2020-04-21 With WOMS mainly running off of nexgen these days, most of the track data is missing composers. While we agreed that it should not be a frontend task to decide which data source is correct/valid and that our APIs should be able to be trusted, until we can fix the music master link with WOMs (the real solution) we determined the best workaround is to call publisher's crusty playlist API to fill in the missing data after every WOMs update. This temporarily makes WOMs more of a service that says "hey, there's an update available! Go find out what it is" rather than telling us what that update is. Sad trombone* -JK
 
-    We should be able to stop this once this gets fixed: https://jira.wnyc.org/browse/DSODA-375
+    TODO: We should be able to stop this once this gets fixed: https://jira.wnyc.org/browse/DSODA-375
     */
 
     return await this.loadSchedule(moment.tz(moment(), "America/New_York"))

--- a/app/services/woms.js
+++ b/app/services/woms.js
@@ -60,7 +60,7 @@ export default Service.extend({
 
   socketMessageHandler(event) {
     let data = JSON.parse(event.data);
-    // HACK: filter out invalid messages from woms.
+    // TODO: fix hack that filters out invalid messages from woms.
     // Real solution should be to remove the duplicate messages
     // https://jira.wnyc.org/browse/DSODA-398
     if (data) {


### PR DESCRIPTION
This crudely merges incoming (and mostly likely incomplete) records from woms with existing (mostly likely more complete) records we have in the ember-data store from publisher. This prevents the UI from flashing needlessly when records get updated with incorrect data, rendered, corrected by publisher data, and rendered again.